### PR TITLE
Add Mobile Touch Controls and Title Screen Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,16 @@ Open the Vite URL shown in the terminal. The game keeps the original 1080x1920 l
 - Art files live in `assets/art`.
 - Audio files live in `assets/sounds`.
 
-## Controls
+## Desktop Controls
 
 - Move: Arrow keys, WASD
 - Start: Space bar
 - Honk: Space bar during gameplay
 - Retry after game over: R
+
+## Mobile Controls
+
+- Start: Tap the title screen
+- Move: Touch D-pad
+- Honk: Honk button during gameplay
+- Retry after game over: Tap the retry prompt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,920 @@
+{
+  "name": "wilber-world",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wilber-world",
+      "version": "1.0.0",
+      "dependencies": {
+        "phaser": "4.1.0"
+      },
+      "devDependencies": {
+        "vite": "^8.0.16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/phaser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.1.0.tgz",
+      "integrity": "sha512-ZXv5Bhyg2BqJGAAxNI2xvmzGXW9q+TwUG1RLri5ZDBYGGtcma6aWUO/eJ7EbozeqRd5fKdpo4ycNMQt+Bi5iYg==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "phaser": "4.1.0"
   },
   "devDependencies": {
-    "vite": "^5.4.19"
+    "vite": "^8.0.16"
   }
 }

--- a/src/inputMode.js
+++ b/src/inputMode.js
@@ -1,0 +1,23 @@
+export function usesTouchControls() {
+  const params = new URLSearchParams(window.location.search);
+
+  if (params.has('touchControls')) {
+    return true;
+  }
+
+  if (params.has('desktopControls')) {
+    return false;
+  }
+
+  const hasTouchPoints = navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+  const hasCoarsePrimaryPointer = window.matchMedia?.('(pointer: coarse)').matches ?? false;
+  const canHover = window.matchMedia?.('(hover: hover)').matches ?? false;
+  const mobileUserAgent = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+  const compactPortraitViewport = window.innerWidth <= 820 && window.innerHeight >= window.innerWidth;
+
+  if (mobileUserAgent && hasTouchPoints) {
+    return true;
+  }
+
+  return hasTouchPoints && hasCoarsePrimaryPointer && !canHover && compactPortraitViewport;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,11 @@ import { PreloadScene } from './scenes/PreloadScene.js';
 import { TitleScene } from './scenes/TitleScene.js';
 import { PlayScene } from './scenes/PlayScene.js';
 import { WinScene } from './scenes/WinScene.js';
+import { usesTouchControls } from './inputMode.js';
 
 window.__wilberSpaceAction = null;
+window.__wilberTouchAction = null;
+window.__wilberTouchControlAction = null;
 
 // Capture Space at the window level so it never scrolls or refreshes the page.
 // Scenes replace this callback with their current Space-bar behavior.
@@ -30,6 +33,30 @@ function installSpaceKeyCapture() {
 
   window.addEventListener('keydown', handleSpace, true);
   window.addEventListener('keyup', handleSpace, true);
+}
+
+function installTouchGestureGuards() {
+  if (!usesTouchControls()) {
+    return;
+  }
+
+  const handleTouch = (event) => {
+    event.preventDefault();
+    window.__wilberTouchControlAction?.(event);
+
+    if (event.type === 'touchstart') {
+      window.__wilberTouchAction?.();
+    }
+  };
+  const options = {
+    capture: true,
+    passive: false
+  };
+
+  window.addEventListener('touchstart', handleTouch, options);
+  window.addEventListener('touchmove', handleTouch, options);
+  window.addEventListener('touchend', handleTouch, options);
+  window.addEventListener('gesturestart', handleTouch, options);
 }
 
 function focusGameSurface() {
@@ -61,6 +88,7 @@ async function waitForFonts() {
 
 async function startGame() {
   installSpaceKeyCapture();
+  installTouchGestureGuards();
   focusGameSurface();
   await waitForFonts();
 
@@ -75,6 +103,9 @@ async function startGame() {
       arcade: {
         gravity: { y: 200 }
       }
+    },
+    input: {
+      activePointers: 4
     },
     scale: {
       mode: Phaser.Scale.FIT,

--- a/src/scenes/PlayScene.js
+++ b/src/scenes/PlayScene.js
@@ -13,8 +13,10 @@ import {
   PIXEL_FONT,
   START_DELAY
 } from '../constants.js';
+import { usesTouchControls } from '../inputMode.js';
 
 const HUD_DEPTH = 20;
+const TOUCH_CONTROL_DEPTH = 30;
 const WORLD_GRAVITY_START = 200;
 const ENEMY_GRAVITY_STEP = 16.6;
 const SPAWN_DELAY_START = 1000;
@@ -35,6 +37,17 @@ const PLAYER_BOUNDS_DELAY = 3000;
 const COUNTDOWN_Y = 300;
 const COUNTDOWN_FONT_SIZE = '100px';
 const COUNTDOWN_LIFETIME = 650;
+const MAX_SCROLL_DELTA = 1000 / 60;
+const TOUCH_BUTTON_RADIUS = 78;
+const TOUCH_BUTTON_SIZE = 170;
+const TOUCH_BUTTON_ALPHA = 0.18;
+const TOUCH_BUTTON_PRESSED_ALPHA = 0.36;
+const TOUCH_BUTTON_STROKE_ALPHA = 0.55;
+const TOUCH_DPAD_X = 210;
+const TOUCH_DPAD_Y = 1580;
+const TOUCH_DPAD_SPACING = 126;
+const TOUCH_HORN_X = 870;
+const TOUCH_HORN_Y = 1630;
 
 // These values preserve the hand-tuned countdown/audio sync.
 // Adjust the "at" timings directly when matching a cue in game.mp3.
@@ -74,6 +87,17 @@ export class PlayScene extends Phaser.Scene {
       invulnerable: false
     };
     this.hudDepth = HUD_DEPTH;
+    this.isTouchMode = usesTouchControls();
+    this.touchDirections = {
+      left: false,
+      right: false,
+      up: false,
+      down: false
+    };
+    this.touchControls = [];
+    this.touchButtonStates = [];
+    this.touchHornButton = null;
+    this.touchHornPressed = false;
 
     // Enemy speed is driven by world gravity; the player opts out of gravity so
     // it only moves when the player gives input.
@@ -95,8 +119,8 @@ export class PlayScene extends Phaser.Scene {
     this.physics.add.overlap(this.player, this.enemies, this.handlePlayerHit, undefined, this);
   }
 
-  update() {
-    this.highway.tilePositionY -= this.state.backgroundSpeed;
+  update(_time, delta) {
+    this.highway.tilePositionY -= this.toScrollStep(this.state.backgroundSpeed, delta);
     this.cleanupEnemies();
 
     if (!this.state.ended) {
@@ -140,11 +164,14 @@ export class PlayScene extends Phaser.Scene {
   }
 
   createHud() {
-    this.livesText = this.add.text(25, 1820, 'Lives: 3', this.hudTextStyle()).setDepth(this.hudDepth).setVisible(false);
     this.timerText = this.add.text(GAME_WIDTH / 2, 100, `Time: ${LEVEL_SECONDS}`, {
       ...this.hudTextStyle(),
       fontSize: '50px'
     }).setOrigin(0.5, 0).setDepth(this.hudDepth).setVisible(false);
+    this.livesText = this.add.text(GAME_WIDTH / 2, 175, 'Lives: 3', this.hudTextStyle())
+      .setOrigin(0.5, 0)
+      .setDepth(this.hudDepth)
+      .setVisible(false);
   }
 
   createInput() {
@@ -156,6 +183,10 @@ export class PlayScene extends Phaser.Scene {
       right: Phaser.Input.Keyboard.KeyCodes.D,
       restart: Phaser.Input.Keyboard.KeyCodes.R
     });
+
+    if (this.isTouchMode) {
+      this.createTouchControls();
+    }
   }
 
   registerSpaceAction() {
@@ -233,6 +264,7 @@ export class PlayScene extends Phaser.Scene {
     this.state.controlsEnabled = true;
     this.livesText.setVisible(true);
     this.timerText.setVisible(true);
+    this.setTouchControlsVisible(true);
 
     this.spawnEvent = this.time.addEvent({
       delay: this.state.spawnDelay,
@@ -299,25 +331,226 @@ export class PlayScene extends Phaser.Scene {
       return;
     }
 
-    const movingLeft = this.cursors.left.isDown || this.keys.left.isDown;
-    const movingRight = this.cursors.right.isDown || this.keys.right.isDown;
-    const movingUp = this.cursors.up.isDown || this.keys.up.isDown;
-    const movingDown = this.cursors.down.isDown || this.keys.down.isDown;
+    const movement = this.getMovementInput();
 
-    if (movingLeft) {
+    if (movement.left) {
       this.player.setVelocityX(-PLAYER_SPEED_X);
       this.player.setAngle(-10);
-    } else if (movingRight) {
+    } else if (movement.right) {
       this.player.setVelocityX(PLAYER_SPEED_X);
       this.player.setAngle(10);
     } else {
       this.player.setRotation(0);
     }
 
-    if (movingUp) {
+    if (movement.up) {
       this.player.setVelocityY(-PLAYER_SPEED_UP);
-    } else if (movingDown) {
+    } else if (movement.down) {
       this.player.setVelocityY(PLAYER_SPEED_DOWN);
+    }
+  }
+
+  getMovementInput() {
+    return {
+      left: this.cursors.left.isDown || this.keys.left.isDown || this.touchDirections.left,
+      right: this.cursors.right.isDown || this.keys.right.isDown || this.touchDirections.right,
+      up: this.cursors.up.isDown || this.keys.up.isDown || this.touchDirections.up,
+      down: this.cursors.down.isDown || this.keys.down.isDown || this.touchDirections.down
+    };
+  }
+
+  createTouchControls() {
+    this.createDirectionButton('up', TOUCH_DPAD_X, TOUCH_DPAD_Y - TOUCH_DPAD_SPACING, 90);
+    this.createDirectionButton('left', TOUCH_DPAD_X - TOUCH_DPAD_SPACING, TOUCH_DPAD_Y, 0);
+    this.createDirectionButton('right', TOUCH_DPAD_X + TOUCH_DPAD_SPACING, TOUCH_DPAD_Y, 180);
+    this.createDirectionButton('down', TOUCH_DPAD_X, TOUCH_DPAD_Y + TOUCH_DPAD_SPACING, -90);
+    this.createHornButton();
+    this.setTouchControlsVisible(false);
+
+    this.touchControlAction = (event) => this.handleTouchControls(event);
+    window.__wilberTouchControlAction = this.touchControlAction;
+
+    this.events.once('shutdown', () => {
+      if (window.__wilberTouchControlAction === this.touchControlAction) {
+        window.__wilberTouchControlAction = null;
+      }
+      this.clearTouchDirections();
+    });
+  }
+
+  createDirectionButton(direction, x, y, angle) {
+    const button = this.createTouchButton(x, y, null, {
+      angle,
+      chevron: true
+    });
+    const state = {
+      direction,
+      x,
+      y,
+      size: TOUCH_BUTTON_SIZE,
+      background: button.background
+    };
+
+    this.touchButtonStates.push(state);
+  }
+
+  createHornButton() {
+    const button = this.createTouchButton(TOUCH_HORN_X, TOUCH_HORN_Y, 'Honk', {
+      fontSize: '25px',
+      radius: 86,
+      size: 190
+    });
+
+    this.touchHornButton = {
+      x: TOUCH_HORN_X,
+      y: TOUCH_HORN_Y,
+      size: 190,
+      background: button.background
+    };
+  }
+
+  createTouchButton(x, y, label, options = {}) {
+    const radius = options.radius ?? TOUCH_BUTTON_RADIUS;
+    const size = options.size ?? TOUCH_BUTTON_SIZE;
+    const background = this.add.circle(x, y, radius, 0xffffff, TOUCH_BUTTON_ALPHA)
+      .setStrokeStyle(5, 0xffffff, TOUCH_BUTTON_STROKE_ALPHA)
+      .setDepth(TOUCH_CONTROL_DEPTH);
+    const foreground = options.chevron
+      ? this.createChevronIcon(x, y, options.angle ?? 0)
+      : this.add.text(x, y, label, {
+        fontFamily: PIXEL_FONT,
+        fontSize: options.fontSize ?? '52px',
+        color: '#ffffff'
+      })
+        .setOrigin(0.5)
+        .setDepth(TOUCH_CONTROL_DEPTH + 1);
+    const zone = this.add.zone(x, y, size, size)
+      .setDepth(TOUCH_CONTROL_DEPTH + 2)
+      .setInteractive();
+
+    this.touchControls.push({ background, text: foreground, zone });
+
+    return { background, text: foreground, zone };
+  }
+
+  createChevronIcon(x, y, angle) {
+    const graphic = this.add.graphics();
+    graphic.lineStyle(10, 0xffffff, 1);
+    graphic.beginPath();
+    graphic.moveTo(22, -34);
+    graphic.lineTo(-22, 0);
+    graphic.lineTo(22, 34);
+    graphic.strokePath();
+
+    return this.add.container(x, y, [graphic])
+      .setAngle(angle)
+      .setDepth(TOUCH_CONTROL_DEPTH + 1);
+  }
+
+  handleTouchControls(event) {
+    if (!this.state.controlsEnabled || this.state.ended) {
+      this.clearTouchDirections();
+      return;
+    }
+
+    const points = Array.from(event.touches ?? [])
+      .map((touch) => this.getTouchGamePoint(touch))
+      .filter(Boolean);
+    const isTouchingControl = points.some((point) => this.isPointInsideAnyTouchControl(point));
+
+    if (!isTouchingControl && !this.isAnyTouchControlPressed()) {
+      return;
+    }
+
+    this.touchButtonStates.forEach((state) => {
+      const isPressed = points.some((point) => this.isPointInsideTouchButton(point, state));
+      this.updateDirectionButtonState(state, isPressed);
+    });
+
+    const hornPressed = Boolean(this.touchHornButton)
+      && points.some((point) => this.isPointInsideTouchButton(point, this.touchHornButton));
+    this.updateHornButtonState(hornPressed);
+  }
+
+  getTouchGamePoint(touch) {
+    const canvas = this.game.canvas;
+    const bounds = canvas.getBoundingClientRect();
+
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      return null;
+    }
+
+    return {
+      x: (touch.clientX - bounds.left) * (GAME_WIDTH / bounds.width),
+      y: (touch.clientY - bounds.top) * (GAME_HEIGHT / bounds.height)
+    };
+  }
+
+  isPointInsideTouchButton(point, button) {
+    const halfSize = button.size / 2;
+
+    return point.x >= button.x - halfSize
+      && point.x <= button.x + halfSize
+      && point.y >= button.y - halfSize
+      && point.y <= button.y + halfSize;
+  }
+
+  isPointInsideAnyTouchControl(point) {
+    return this.touchButtonStates.some((state) => this.isPointInsideTouchButton(point, state))
+      || (this.touchHornButton && this.isPointInsideTouchButton(point, this.touchHornButton));
+  }
+
+  isAnyTouchControlPressed() {
+    return Object.values(this.touchDirections).some(Boolean) || this.touchHornPressed;
+  }
+
+  updateDirectionButtonState(state, isPressed) {
+    this.touchDirections[state.direction] = isPressed;
+    state.background.setAlpha(isPressed ? TOUCH_BUTTON_PRESSED_ALPHA : TOUCH_BUTTON_ALPHA);
+  }
+
+  updateHornButtonState(isPressed) {
+    if (!this.touchHornButton) {
+      return;
+    }
+
+    if (isPressed && !this.touchHornPressed) {
+      this.honkHorn();
+    }
+
+    this.touchHornPressed = isPressed;
+    this.touchHornButton.background.setAlpha(isPressed ? TOUCH_BUTTON_PRESSED_ALPHA : TOUCH_BUTTON_ALPHA);
+  }
+
+  clearTouchDirections() {
+    Object.keys(this.touchDirections).forEach((direction) => {
+      this.touchDirections[direction] = false;
+    });
+    this.touchButtonStates.forEach((state) => {
+      state.background.setAlpha(TOUCH_BUTTON_ALPHA);
+    });
+    this.touchHornPressed = false;
+    this.touchHornButton?.background.setAlpha(TOUCH_BUTTON_ALPHA);
+  }
+
+  setTouchControlsVisible(visible) {
+    if (!this.isTouchMode) {
+      return;
+    }
+
+    this.touchControls.forEach(({ background, text, zone }) => {
+      background.setVisible(visible);
+      text.setVisible(visible);
+
+      if (visible) {
+        zone.setVisible(true).setInteractive();
+      } else {
+        zone.setVisible(false).disableInteractive();
+      }
+    });
+
+    if (!visible) {
+      this.clearTouchDirections();
     }
   }
 
@@ -397,6 +630,7 @@ export class PlayScene extends Phaser.Scene {
 
     this.state.ended = true;
     this.state.controlsEnabled = false;
+    this.setTouchControlsVisible(false);
     this.tweens.killTweensOf(this.player);
     this.player.setAngle(0);
     this.player.setVelocity(0, 0);
@@ -465,6 +699,7 @@ export class PlayScene extends Phaser.Scene {
 
     this.state.ended = true;
     this.state.controlsEnabled = false;
+    this.setTouchControlsVisible(false);
     this.music?.stop();
     this.stopEvents();
 
@@ -484,17 +719,28 @@ export class PlayScene extends Phaser.Scene {
         fontSize: '75px',
         color: '#ffffff'
       }).setOrigin(0.5, 0).setDepth(this.hudDepth);
-      this.add.text(GAME_WIDTH / 2, 900, 'Press R to Retry', {
+      this.add.text(GAME_WIDTH / 2, 900, this.isTouchMode ? 'Tap To Retry' : 'Press R to Retry', {
         fontFamily: PIXEL_FONT,
         fontSize: '42px',
         color: '#ffffff'
       }).setOrigin(0.5, 0).setDepth(this.hudDepth);
+
+      if (this.isTouchMode) {
+        this.retryTouchAction = () => this.restartAfterGameOver();
+        window.__wilberTouchAction = this.retryTouchAction;
+        this.input.once('pointerdown', () => this.restartAfterGameOver());
+      }
     });
 
-    this.input.keyboard.once('keydown-R', () => {
-      this.deadSound?.stop();
-      this.scene.restart();
-    });
+    this.input.keyboard.once('keydown-R', () => this.restartAfterGameOver());
+  }
+
+  restartAfterGameOver() {
+    if (window.__wilberTouchAction === this.retryTouchAction) {
+      window.__wilberTouchAction = null;
+    }
+    this.deadSound?.stop();
+    this.scene.restart();
   }
 
   stopEvents() {
@@ -508,5 +754,11 @@ export class PlayScene extends Phaser.Scene {
       fontSize: '35px',
       color: '#ffffff'
     };
+  }
+
+  toScrollStep(speed, delta) {
+    // Touch dragging can create occasional long mobile frames. Capping the road
+    // delta prevents the texture from visually "catching up" and seeming faster.
+    return speed * (Math.min(delta, MAX_SCROLL_DELTA) / MAX_SCROLL_DELTA);
   }
 }

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -1,11 +1,13 @@
 import Phaser from 'phaser';
 import { ENEMY_KEYS, GAME_HEIGHT, GAME_WIDTH, LANES, PIXEL_FONT } from '../constants.js';
+import { usesTouchControls } from '../inputMode.js';
 
 const ROAD_SCROLL_SPEED = 18;
 const OVERLAY_DEPTH = 20;
 const ENEMY_DEPTH = 5;
 const TITLE_OVERLAY_ALPHA = 0.25;
 const PROMPT_Y = 1000;
+const INSTRUCTIONS_Y = 1135;
 const PROMPT_GAP = 38;
 const PROMPT_OFFSET_X = 7;
 const SPACE_BAR_SCALE = 1.25;
@@ -14,6 +16,7 @@ const ENEMY_SPAWN_DELAY = 1000;
 const ENEMY_SPAWN_Y = -350;
 const ENEMY_CLEANUP_Y = GAME_HEIGHT + 500;
 const ENEMY_SCALE = 0.8;
+const MAX_SCROLL_DELTA = 1000 / 60;
 
 export class TitleScene extends Phaser.Scene {
   constructor() {
@@ -22,6 +25,7 @@ export class TitleScene extends Phaser.Scene {
 
   create() {
     this.starting = false;
+    this.isTouchMode = usesTouchControls();
 
     // The title screen reuses the gameplay road and falling cars so it feels alive
     // before the player starts the actual round.
@@ -36,6 +40,32 @@ export class TitleScene extends Phaser.Scene {
 
     this.add.image(0, 0, 'black').setOrigin(0).setAlpha(TITLE_OVERLAY_ALPHA).setDepth(10);
 
+    if (this.isTouchMode) {
+      this.createTouchPrompt();
+      this.touchAction = () => this.startGame();
+      window.__wilberTouchAction = this.touchAction;
+      this.input.once('pointerdown', () => this.startGame());
+    } else {
+      this.createKeyboardPrompt();
+    }
+
+    this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+    this.input.keyboard.addCapture?.(Phaser.Input.Keyboard.KeyCodes.SPACE);
+
+    // main.js routes captured Space presses to whichever scene owns this callback.
+    this.spaceAction = () => this.startGame();
+    window.__wilberSpaceAction = this.spaceAction;
+    this.events.once('shutdown', () => {
+      if (window.__wilberSpaceAction === this.spaceAction) {
+        window.__wilberSpaceAction = null;
+      }
+      if (window.__wilberTouchAction === this.touchAction) {
+        window.__wilberTouchAction = null;
+      }
+    });
+  }
+
+  createKeyboardPrompt() {
     // The prompt is built from text plus the animated Space bar sprite so spacing
     // can be tuned independently from the art.
     const pressText = this.add.text(0, PROMPT_Y, 'Press', this.titleTextStyle()).setDepth(OVERLAY_DEPTH);
@@ -49,21 +79,33 @@ export class TitleScene extends Phaser.Scene {
     startText.setPosition(promptLeft + pressText.width + PROMPT_GAP + spaceBar.displayWidth + PROMPT_GAP, PROMPT_Y);
     spaceBar.play('press');
 
-    this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
-    this.input.keyboard.addCapture?.(Phaser.Input.Keyboard.KeyCodes.SPACE);
-
-    // main.js routes captured Space presses to whichever scene owns this callback.
-    this.spaceAction = () => this.startGame();
-    window.__wilberSpaceAction = this.spaceAction;
-    this.events.once('shutdown', () => {
-      if (window.__wilberSpaceAction === this.spaceAction) {
-        window.__wilberSpaceAction = null;
-      }
-    });
+    this.createInstructions([
+      'Avoid Cars',
+      'Survive Until Time Runs Out',
+      '--------------------------',
+      'Arrows / WASD To Drive',
+      'Space Bar To Honk'
+    ]);
   }
 
-  update() {
-    this.highway.tilePositionY -= ROAD_SCROLL_SPEED;
+  createTouchPrompt() {
+    this.add.text(GAME_WIDTH / 2, PROMPT_Y, 'Tap To Start', this.titleTextStyle())
+      .setOrigin(0.5, 0)
+      .setDepth(OVERLAY_DEPTH);
+    this.createInstructions([
+      'Avoid Cars',
+      'Survive Until Time Runs Out'
+    ]);
+  }
+
+  createInstructions(lines) {
+    this.add.text(GAME_WIDTH / 2, INSTRUCTIONS_Y, lines.join('\n'), this.instructionTextStyle())
+      .setOrigin(0.5, 0)
+      .setDepth(OVERLAY_DEPTH);
+  }
+
+  update(_time, delta) {
+    this.highway.tilePositionY -= this.toScrollStep(ROAD_SCROLL_SPEED, delta);
     this.cleanupEnemies();
 
     if (Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
@@ -102,5 +144,19 @@ export class TitleScene extends Phaser.Scene {
       fontSize: '35px',
       color: '#ffffff'
     };
+  }
+
+  instructionTextStyle() {
+    return {
+      fontFamily: PIXEL_FONT,
+      fontSize: '24px',
+      color: '#ffffff',
+      align: 'center',
+      lineSpacing: 20
+    };
+  }
+
+  toScrollStep(speed, delta) {
+    return speed * (Math.min(delta, MAX_SCROLL_DELTA) / MAX_SCROLL_DELTA);
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,14 +4,27 @@ body,
   width: 100%;
   height: 100%;
   margin: 0;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+@supports (height: 100svh) {
+  html,
+  body,
+  #game {
+    height: 100svh;
+  }
 }
 
 body {
   overflow: hidden;
   background: #050505;
   font-family: "Press Start 2P", "Courier New", monospace;
+  overscroll-behavior: none;
 }
 
 canvas {
   display: block;
+  touch-action: none;
 }


### PR DESCRIPTION
- Added automatic desktop/mobile control detection.
- Added mobile title flow with `Tap To Start`.
- Added mobile touch controls with a virtual D-pad and honk button.
- Added mobile tap-to-retry behavior after game over.
- Kept desktop controls keyboard-focused with Space bar start/honk and `R` retry.
- Updated title screen instructions:
  - shared goal text for desktop and mobile
  - desktop-only keyboard/honk instructions
- Moved lives HUD under the timer at the top of the screen.
- Added touch/browser guardrails to prevent mobile scrolling gestures during gameplay.
- Updated mobile D-pad arrows with centered line-art chevrons.
- Updated README controls for desktop and mobile.
- Added `package-lock.json` and updated Vite dependency after npm audit/install changes.
- Verified with `npm run build`.